### PR TITLE
Make .gitignore ignore .DS_Store everywhere

### DIFF
--- a/salvaguarda/.gitignore
+++ b/salvaguarda/.gitignore
@@ -11,4 +11,4 @@ npm-debug.*
 web-build/
 
 # macOS
-.DS_Store
+**/.DS_Store


### PR DESCRIPTION
.DS_Store is a file containing metadata from local MacOS directories, and it shouldn't be present in source control. There was already a rule for this in .gitignore, but it did not prevent the file from showing up at the top level repo directory. Now it should be ignored at every directory in the repo.